### PR TITLE
Set up nginx/ELB properly for prod.

### DIFF
--- a/aws.yml
+++ b/aws.yml
@@ -24,6 +24,7 @@
         vpc_id: vpc-1e467077
     vpc_id: "{{ regions[region].vpc_id }}"
     ami_id: "{{ regions[region].ami_id }}"
+    elb_ssl_arn: "arn:aws:iam::225244788755:server-certificate/prod-multidomain"
 
     lc_num: 10
     old_lc_num: "{{ lc_num - 1 }}"
@@ -46,6 +47,10 @@
           - proto: tcp
             from_port: 80
             to_port: 80
+            cidr_ip: 0.0.0.0/0
+          - proto: tcp
+            from_port: 443
+            to_port: 443
             cidr_ip: 0.0.0.0/0
       register: sg_elb
 
@@ -79,6 +84,11 @@
           - protocol: http
             load_balancer_port: 80
             instance_port: 80
+          - protocol: https
+            load_balancer_port: 443
+            instance_port: 80
+            instance_protocol: http
+            ssl_certificate_id: "{{ elb_ssl_arn }}"
         health_check:
           ping_protocol: http
           ping_port: 80

--- a/aws.yml
+++ b/aws.yml
@@ -16,16 +16,16 @@
     region: "{{ lookup('env', 'AWS_REGION') or 'eu-west-1' }}"
     regions:
       eu-west-1:
-        ami_id: ami-2ea53c5d
+        ami_id: ami-616af312
         # The default VPC
         vpc_id: vpc-e2c30986
       eu-central-1:
-        ami_id: ami-f5f8109a
+        ami_id: ami-b6f61ed9
         vpc_id: vpc-1e467077
     vpc_id: "{{ regions[region].vpc_id }}"
     ami_id: "{{ regions[region].ami_id }}"
 
-    lc_num: 7
+    lc_num: 10
     old_lc_num: "{{ lc_num - 1 }}"
     aws_env: "{{ lookup('env', 'ENVIRONMENT') or 'test' }}"
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -35,11 +35,32 @@
   - name: Migrate Django database.
     shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py migrate --noinput"
 
-  - name: Generate Django media.
-    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py collectstatic --noinput"
+  - name: Pre-compile CSS/JS.
+    command: "./env/bin/python code/manage.py compilestatic"
     environment:
      GEM_HOME: "{{ project_root }}/gems"
      PATH: "{{ project_root }}/gems/bin:{{ ansible_env.PATH }}"
+    args:
+      chdir: "{{ project_root }}"
+    when: packer is defined
+
+  - name: Generate Django media.
+    command: "./env/bin/python code/manage.py collectstatic --noinput"
+    environment:
+     GEM_HOME: "{{ project_root }}/gems"
+     PATH: "{{ project_root }}/gems/bin:{{ ansible_env.PATH }}"
+    args:
+      chdir: "{{ project_root }}"
+
+  # If we are running via packer (i.e. on an AWS instance with the right permissions) then we can sync the assets to the S3 bucket
+  - name: Sync assets to S3 bucket
+    command: "/usr/local/bin/aws s3 sync --cache-control 2592000 --metadata-directive REPLACE --acl public-read --exclude staticfiles.json code/polling_stations/static_root/ s3://pollingstations-assets/ --quiet"
+    environment:
+     GEM_HOME: "{{ project_root }}/gems"
+     PATH: "{{ project_root }}/gems/bin:{{ ansible_env.PATH }}"
+    args:
+      chdir: "{{ project_root }}"
+    when: packer is defined
 
   - name: Compile all translations from .po files into .mo files
     shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py compilemessages"

--- a/files/conf/nginx.conf
+++ b/files/conf/nginx.conf
@@ -3,8 +3,19 @@ upstream gunicorn_pollingstations {
 }
 
 server {
-    listen  80;
-    server_name pollingstations.democracyclub.org.uk wheredoivote.co.uk www.wheredoivote.co.uk _ default;
+    listen 80;
+    server_name www.wheredoivote.co.uk pollingstations.democracyclub.org.uk;
+    return 301 https://wheredoivote.co.uk$request_uri;
+}
+
+server {
+    listen 80 default_server;
+    server_name wheredoivote.co.uk _;
+
+    # When behind an ELB X-Forward-Proto is the only indication we have if we came in via https or not.
+    if ($http_x_forwarded_proto = 'http') {
+        return 301 https://$host$request_uri;
+    }
 
     location /static {
         autoindex on;

--- a/files/conf/nginx.conf
+++ b/files/conf/nginx.conf
@@ -2,6 +2,14 @@ upstream gunicorn_pollingstations {
     server unix:/tmp/{{app_name}}.sock;
 }
 
+# We operate behind an ELB, so we need to trust it for the X-Forwarded-For
+# header. Since we can't know what IP address that will come from we have to
+# trust that when coming from any private IP range.
+set_real_ip_from 192.168.0.0/16;
+set_real_ip_from 172.16.0.0/12;
+set_real_ip_from 10.0.0.0/8;
+real_ip_header X-Forwarded-For;
+
 server {
     listen 80;
     server_name www.wheredoivote.co.uk pollingstations.democracyclub.org.uk;
@@ -17,6 +25,7 @@ server {
         return 301 https://$host$request_uri;
     }
 
+    # Fallback - this should be served from S3 but if we mess up somewhere else lets support this
     location /static {
         autoindex on;
         alias {{ project_root }}/code/{{ app_name }}/static_root/;

--- a/iam_policies/packer-ami-builder.json
+++ b/iam_policies/packer-ami-builder.json
@@ -12,6 +12,21 @@
                 "arn:aws:s3:::pollingstations-packer-assets",
                 "arn:aws:s3:::pollingstations-packer-assets/*"
             ]
+        },
+        {
+            "Sid": "StaticAssetS3Sync",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:ListBucket"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::pollingstations-assets",
+                "arn:aws:s3:::pollingstations-assets/*"
+            ]
         }
     ]
 }

--- a/packer-setup-playbook.yml
+++ b/packer-setup-playbook.yml
@@ -16,6 +16,11 @@
         name: pollingstations-packer-assets
       register: s3_bucket
 
+    - name: App assets bucket
+      s3_bucket:
+        name: pollingstations-assets
+      register: s3_bucket
+
     - iam:
         name: packer-ami-builder
         iam_type: role

--- a/webapp_settings/production.py
+++ b/webapp_settings/production.py
@@ -28,7 +28,9 @@ DATABASES = {
 }
 DATABASE_ROUTERS = ['polling_stations.db_routers.LoggerRouter',]
 
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
 STATIC_PRECOMPILER_DISABLE_AUTO_COMPILE = True
+STATIC_URL = 'https://s3-eu-west-1.amazonaws.com/pollingstations-assets/'
 
 # We need to also respond to the private IP address of the instance as that's
 # what the ELB will send healthcheck requests to


### PR DESCRIPTION
- Use S3 for assets to move load off our instances
- Add an SSL cert to the ELB
- Redirect from http to https (and from www to bare domain)
- Have accurate IPs in access logs, not the ELB ip address.