### PR TITLE
Hard-code fetching EE from master branch

### DIFF
--- a/roles/every_election/defaults/main.yml
+++ b/roles/every_election/defaults/main.yml
@@ -1,3 +1,4 @@
 ee_name: every_election
 ee_project_root: /var/www/every_election
 ee_project_repo: https://github.com/DemocracyClub/EveryElection.git
+ee_branch: master

--- a/roles/every_election/tasks/main.yml
+++ b/roles/every_election/tasks/main.yml
@@ -49,7 +49,7 @@
   git:
     repo: "{{ ee_project_repo }}"
     dest: "{{ ee_project_root }}/code/"
-    version: "{{ branch }}"
+    version: "{{ ee_branch | default(master) }}"
     accept_hostkey: true
   become_user: "{{ ee_name }}"
   notify:


### PR DESCRIPTION
i.e: if we're deploying from a branch of the wheredoivote repo that is not `master`, don't try to clone that same branch from the EE repo