### PR TITLE
disable checks when importing data

### DIFF
--- a/import_data.yml
+++ b/import_data.yml
@@ -11,7 +11,7 @@
 
   tasks:
   - name: Import data
-    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import -e '{{ election_regex }}' -r --multiprocessing"
+    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import -e '{{ election_regex }}' -r --multiprocessing --nochecks"
     args:
        executable: /bin/bash
        chdir: "{{ project_root }}"


### PR DESCRIPTION
Checks are for the dev process. When we are building an image,
issues should be sorted. We just want the scripts to run fast.