### PR TITLE
update SSL cert ARN

### DIFF
--- a/aws.yml
+++ b/aws.yml
@@ -24,7 +24,7 @@
       #   vpc_id: vpc-1e467077
     vpc_id: "{{ regions[region].vpc_id }}"
     ami_id: "{{ regions[region].ami_id }}"
-    elb_ssl_arn: "arn:aws:iam::225244788755:server-certificate/ps-prod-10"
+    elb_ssl_arn: "arn:aws:acm:eu-west-1:225244788755:certificate/029b3eed-b3d9-403b-9cbf-ec8077f62a6b"
 
     lc_num: 47
     old_lc_num: "{{ lc_num - 1 }}"


### PR DESCRIPTION
This is the cert that the prod and test load balancers are now using, but I set in in the Web GUI so leave this and I'll test it next time I do a deploy before we merge it.

Closes #9 