### PR TITLE
Update with latest deploy changes (7th Dec)

### DIFF
--- a/addressbase.yml
+++ b/addressbase.yml
@@ -12,7 +12,7 @@
   tasks:
 
   - name: Import Councils
-    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils"
+    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils -u {{ alt_boundaries_url }}"
 
   - name: Set ONSPD tmp path
     set_fact:

--- a/addressbase.yml
+++ b/addressbase.yml
@@ -10,8 +10,34 @@
   become_user: "{{ project_name }}"
 
   tasks:
+
   - name: Import Councils
     shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils"
+
+  - name: Set ONSPD tmp path
+    set_fact:
+      onspd_tmp_path: '/tmp/onspd'
+
+  - name: Create the ONSPD tmp dir
+    file: state=directory path={{ onspd_tmp_path }}
+
+  - name: Download ONSPD
+    get_url:
+      url: "{{ onspd_url }}"
+      dest: "{{ onspd_tmp_path }}"
+
+  - name: Unzip ONSPD
+    shell: "unzip \\*.zip"
+    args:
+      chdir: "{{ onspd_tmp_path }}"
+
+  - name: Import ONSPD
+    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_onspd {{ onspd_tmp_path }}/Data"
+
+  - name: Delete ONSPD tmp files
+    file:
+      state: absent
+      path: "{{ onspd_tmp_path }}"
 
   - name: Set addressbase tmp path
     set_fact:

--- a/aws.yml
+++ b/aws.yml
@@ -16,7 +16,7 @@
     region: "{{ lookup('env', 'AWS_REGION') or 'eu-west-1' }}"
     regions:
       eu-west-1:
-        ami_id: ami-34852a4d
+        ami_id: ami-8264ddfb
         # The default VPC
         vpc_id: vpc-e2c30986
       # eu-central-1:
@@ -26,7 +26,7 @@
     ami_id: "{{ regions[region].ami_id }}"
     elb_ssl_arn: "arn:aws:acm:eu-west-1:225244788755:certificate/029b3eed-b3d9-403b-9cbf-ec8077f62a6b"
 
-    lc_num: 50
+    lc_num: 51
     old_lc_num: "{{ lc_num - 1 }}"
     aws_env: "{{ lookup('env', 'ENVIRONMENT') or 'test' }}"
 

--- a/packer
+++ b/packer
@@ -2,6 +2,6 @@
 # Run with:
 # ./packer database
 # ./packer server
-type="${1?Usage $0 '[server|database]'}"
+type="${1?Usage $0 '[addressbase|imported-db|server]'}"
 shift;
 /usr/bin/env packer build -var-file=packer-vars.json -var-file=packer-user-vars.json -only="${type}" "$@" packer.json

--- a/packer-vars.json
+++ b/packer-vars.json
@@ -1,5 +1,5 @@
 {
-  "database_ami_id": "ami-46339f3f",
-  "imported-db_ami_id": "ami-02842b7b",
+  "database_ami_id": "ami-7f6ad306",
+  "imported-db_ami_id": "ami-7f58e106",
   "election_regex": "local.2018-05-03"
 }

--- a/packer.json
+++ b/packer.json
@@ -91,6 +91,7 @@
       "playbook_file": "./provision.yml",
       "groups":["production", "servers", "remote"],
       "extra_arguments": [
+        "--extra-vars", "use_logger=0",
         "--extra-vars", "nickname=production packer=1 build_region={{ user `build_region` }} packer_addressbase=1 branch={{user `branch`}}",
         "--extra-vars", "@vault.yml"
       ]

--- a/provision.yml
+++ b/provision.yml
@@ -140,9 +140,3 @@
 
 - include: import_data.yml
   when: packer_import_data is defined
-
-- hosts: servers
-  vars_files:
-    - vars.yml
-  gather_facts: true
-  become: true

--- a/vars.yml
+++ b/vars.yml
@@ -7,6 +7,7 @@ django_media_root: /var/www/polling_stations-media/media_root
 project_repo: https://github.com/DemocracyClub/UK-Polling-Stations.git
 addressbase_folder_name: DCS0002914854
 onsud_url: https://ons.maps.arcgis.com/sharing/rest/content/items/af42f8d2755a4537883cc161378c7d8c/data
+onspd_url: https://ons.maps.arcgis.com/sharing/rest/content/items/7e76a3bcb0ad4826aba893d252a18c29/data
 use_logger: 1
 packer: 0
 branch: master

--- a/vars.yml
+++ b/vars.yml
@@ -8,6 +8,7 @@ project_repo: https://github.com/DemocracyClub/UK-Polling-Stations.git
 addressbase_folder_name: DCS0002914854
 onsud_url: https://ons.maps.arcgis.com/sharing/rest/content/items/af42f8d2755a4537883cc161378c7d8c/data
 onspd_url: https://ons.maps.arcgis.com/sharing/rest/content/items/7e76a3bcb0ad4826aba893d252a18c29/data
+alt_boundaries_url: https://s3-eu-west-1.amazonaws.com/ons-cache/Local_Authority_Districts_December_2016_Full_Extent_Boundaries_in_the_UK_WGS84.geojson
 use_logger: 1
 packer: 0
 branch: master

--- a/vars.yml
+++ b/vars.yml
@@ -5,7 +5,7 @@ app_name: polling_stations
 django_media_path: polling_stations
 django_media_root: /var/www/polling_stations-media/media_root
 project_repo: https://github.com/DemocracyClub/UK-Polling-Stations.git
-addressbase_folder_name: DCS0002857386
+addressbase_folder_name: DCS0002914854
 onsud_url: https://ons.maps.arcgis.com/sharing/rest/content/items/af42f8d2755a4537883cc161378c7d8c/data
 use_logger: 1
 packer: 0


### PR DESCRIPTION
1629cde and 4bb37c1 are the changes I made related to hitting https://github.com/DemocracyClub/UK-Polling-Stations/issues/1110

The more I think about this, the more I reckon it is probably a mistake or oversight that we had logger enabled in the addressbase build in the first place - performing operations against that DB while building an image has the potential to break stuff on prod. Can you give that a quick sanity check @symroe