### PR TITLE
Flush handlers in misc_fixes.yml

### DIFF
--- a/ad_hoc/misc_fixes.yml
+++ b/ad_hoc/misc_fixes.yml
@@ -18,6 +18,9 @@
     notify:
       - restart web frontend
 
+  - name: Flush handlers
+    meta: flush_handlers
+
   - name: Apply Misc Fixes
     shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py misc_fixes"
     args:


### PR DESCRIPTION
This is for the situation where the git pull changes something on the
frontend - eg template tags, and then there are errors for any requests
that happen between the git pull and misc_fixes being completed. This
should be minimal but is observable when we have a lot of traffix.

By flushing the handler queue the restart 'web frontend task'
will happen before running the various misc fixes. It shouldn't need to
happen after the misc fixes as they're operations on the DB not the
frontend.