### PR TITLE
Sync local to pollingstations-data in addressbase.yml

### DIFF
--- a/addressbase.yml
+++ b/addressbase.yml
@@ -11,6 +11,11 @@
 
   tasks:
 
+  # This isn't used as part of this play, but by baking it in at this stage, we don't have to
+  # download as much in the imported-db stage.
+  - name: Sync S3 bucket
+    shell: "aws s3 sync s3://pollingstations-data/ {{ private_data_path }}"
+
   - name: Import Councils
     shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils -u {{ alt_boundaries_url }}"
     args:


### PR DESCRIPTION
This means we don't have to download the whole 35GiB (as of 2021)
everytime we do an imported-db build