### PR TITLE
Run import_councils on the logger DB

### DIFF
--- a/ad_hoc/update_councils.yml
+++ b/ad_hoc/update_councils.yml
@@ -18,10 +18,17 @@
     notify:
       - restart web frontend
 
-  - name: Import Councils
+  - name: Import Councils on instances
     shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils -u {{ alt_boundaries_url }}"
     args:
       chdir: "{{ project_root }}/code/"
+
+  - name: Import Councils on logger database
+    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils -u {{ alt_boundaries_url }} --database logger"
+    args:
+      chdir: "{{ project_root }}/code/"
+    run_once: True
+
 
   handlers:
     - import_tasks: "../handlers.yml"

--- a/addressbase.yml
+++ b/addressbase.yml
@@ -21,6 +21,12 @@
     args:
       chdir: "{{ project_root }}/code/"
 
+  - name: Import Councils on logger database
+    shell: "{{ project_root }}/env/bin/python {{ project_root }}/code/manage.py import_councils -u {{ alt_boundaries_url }} --database logger"
+    args:
+      chdir: "{{ project_root }}/code/"
+
+
   - name: Set ONSPD tmp path
     set_fact:
       onspd_tmp_path: '/tmp/onspd'

--- a/provision.yml
+++ b/provision.yml
@@ -158,6 +158,14 @@
       minute: "1"
       user: "{{ project_name }}"
 
+  - name: Run import councils on the logger DB hourly
+    cron:
+      name: "Run import councils on the logger DB hourly"
+      job: "/usr/bin/manage-py-command import_councils --only-contact-details --database logger"
+      minute: "1"
+      user: "{{ project_name }}"
+
+
   handlers:
     - import_tasks: handlers.yml
 


### PR DESCRIPTION
Depends on https://github.com/DemocracyClub/UK-Polling-Stations/pull/3950

The main thing to consider here is when / if we want councils in the logger DB to be deleted.

Councils are removed when they no longer show up in the EC API. In reality, they are always likely to be behind us, so once a council is gone from there, it'll be long past the time that we care.

We're going to have to think this through a bit though, to make sure we don't delete something when building an image that we need in production.