### PR TITLE
Add a cron to import EONI data nightly and on reboot

### DIFF
--- a/ad_hoc/import_eoni.yaml
+++ b/ad_hoc/import_eoni.yaml
@@ -1,0 +1,30 @@
+---
+- hosts: all
+  vars_files:
+    - "../vars.yml"
+  gather_facts: true
+  become: true
+  become_user: "{{ project_name }}"
+
+  tasks:
+
+  - name: Pull sources from the repository.
+    git:
+      repo: "{{ project_repo }}"
+      dest: "{{ project_root }}/code/"
+      version: "{{ branch }}"
+      accept_hostkey: true
+      force: yes
+    notify:
+      - restart web frontend
+
+  - name: Flush handlers
+    meta: flush_handlers
+
+  - name: Import EONI from s3
+    shell: "~/import_eoni_from_s3.sh"
+    args:
+      chdir: "{{ project_root }}/code/"
+
+  handlers:
+    - import_tasks: "../handlers.yml"

--- a/files/import_eoni_from_s3.sh
+++ b/files/import_eoni_from_s3.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+set -x
+
+
+LATEST_FILE=$(aws s3 ls s3://eoni-data.wheredoivote.co.uk/production_data/ | sort | tail -n1 | rev | cut -d' ' -f1 | rev)
+SRCDIR='/tmp/eoni_production_data'
+rm -rf $SRCDIR && mkdir -p $SRCDIR
+
+aws s3 cp s3://eoni-data.wheredoivote.co.uk/production_data/"${LATEST_FILE}" $SRCDIR
+
+/var/www/polling_stations/code/env/bin/python /var/www/polling_stations/code/manage.py import_eoni --cleanup $SRCDIR/"${LATEST_FILE}"

--- a/import_eoni.yml
+++ b/import_eoni.yml
@@ -1,0 +1,38 @@
+---
+- hosts: all
+  vars_files:
+    - vars.yml
+  gather_facts: true
+  become: true
+  become_user: "{{ project_name }}"
+  tasks:
+
+  - cronvar:
+      name: MAILTO
+      value: "{{ cron_email }}"
+      user: "{{ project_name }}"
+
+  - name: Install import_eoni_from_s3.sh script
+    template:
+      src: "files/import_eoni_from_s3.sh"
+      dest: "~/import_eoni_from_s3.sh"
+      mode: 0744
+
+  - name: Schedule EONI task on reboot
+    cron:
+      name: "Import EONI Reboot"
+      job: "output-on-error ~/import_eoni_from_s3.sh"
+      user: "{{ project_name }}"
+      special_time: reboot
+    become_user: "{{ project_name }}"
+    become: true
+
+- name: Schedule regular EONI import.
+  cron:
+    name: "Nightly EONI import"
+    minute: 0
+    hour: 2
+    job: "output-on-error ~/import_eoni_from_s3.sh"
+    user: "{{ project_name }}"
+  become_user: "{{ project_name }}"
+  become: true

--- a/provision.yml
+++ b/provision.yml
@@ -180,3 +180,6 @@
 
 - import_playbook: init_db.yml
   when: not packer
+
+- import_playbook: import_eoni.yml
+  when: not packer


### PR DESCRIPTION
This is necessary because EONI want us to stay in sync with a nightly
upload of their data to s3. This means we can't bake their data into an
image build, and instead need to import it when every instance is
started, and then nightly.

This can be turned off by commenting out the playbook import in
provision.yml.